### PR TITLE
Use MediaStreamTrack.stop() when available

### DIFF
--- a/src/elements/audio-processor/audio-processor.js
+++ b/src/elements/audio-processor/audio-processor.js
@@ -136,8 +136,19 @@ class AudioProcessor {
     if (document.hidden) {
       this.sendingAudioData = false;
 
-      if (this.stream)
-        this.stream.stop();
+      if (this.stream) {
+        // Chrome 47+
+        this.stream.getAudioTracks().forEach((track) => {
+          if ('stop' in track) {
+            track.stop();
+          }
+        });
+
+        // Chrome 46-
+        if ('stop' in this.stream) {
+          this.stream.stop();
+        }
+      }
 
       this.stream = null;
     } else {


### PR DESCRIPTION
R: @paullewis 

`MediaStream.stop()` is [no longer supported](https://www.chromestatus.com/feature/5647608089411584) as of Chrome 47.

This PR switches that out to the `MediaStreamTrack.stop()`, though it will still call `MediaStream.stop()` when available.
