### PR TITLE
Allow landscape orientation

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,5 @@
       "type": "image/png"
     }
   ],
-  "display": "standalone",
-  "orientation": "portrait"
+  "display": "standalone"
 }


### PR DESCRIPTION
Allow landscape orientation. Useful for large screen devices e.g. phablets and tablets.
